### PR TITLE
Add baseline security headers for Vercel deployments

### DIFF
--- a/tests/vercel-security-headers.test.js
+++ b/tests/vercel-security-headers.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Vercel security headers', () => {
+  it('configures standard security headers for all routes', () => {
+    const vercelConfigPath = resolve(process.cwd(), 'vercel.json');
+    const vercelConfig = JSON.parse(readFileSync(vercelConfigPath, 'utf-8'));
+
+    const globalHeaders = vercelConfig.headers?.find((entry) => entry.source === '/(.*)');
+    expect(globalHeaders).toBeDefined();
+
+    const headerMap = new Map(globalHeaders.headers.map((header) => [header.key, header.value]));
+
+    expect(headerMap.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(headerMap.get('X-Frame-Options')).toBe('DENY');
+    expect(headerMap.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+    expect(headerMap.get('Permissions-Policy')).toBe('camera=(), microphone=(), geolocation=()');
+    expect(headerMap.get('Strict-Transport-Security')).toContain('max-age=63072000');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -7,8 +7,40 @@
     }
   ],
   "routes": [
-    { "handle": "filesystem" },
-    { "src": "/(?!api/)(.*)", "status": 404, "dest": "/404.html" }
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(?!api/)(.*)",
+      "status": 404,
+      "dest": "/404.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    }
   ]
 }
-


### PR DESCRIPTION
### Motivation
- Ensure the site serves a minimal, consistent set of security headers from the Vercel deployment to reduce common web risks.
- Prevent accidental removal or regressing of the header policy by adding an automated test that validates the configuration.

### Description
- Add a global `headers` block in `vercel.json` with `source: "/(.*)"` that sets `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security` for all routes.
- Add `tests/vercel-security-headers.test.js` which reads `vercel.json` and asserts the presence and expected values of the configured headers.
- Keep existing redirects and routes intact while adding the new headers policy.

### Testing
- Ran `npm test` (Vitest) which executed the test suite including the new `tests/vercel-security-headers.test.js` and completed successfully.
- Test result: 5 test files ran and all tests passed (16 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab378926d0832eb9264c6d3e65fc10)